### PR TITLE
Fix Callbout Boxes Spacing Issue

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -15,6 +15,14 @@
 \usepackage[utf8]{inputenc}
 \usepackage[italian, english]{babel}
 
+\AtEndPreamble{
+    \usepackage[capitalize]{cleveref}
+    \crefname{section}{Sec.}{Secs.}
+    \Crefname{section}{Section}{Sections}
+    \crefname{table}{Tab.}{Tabs.}
+    \Crefname{table}{Table}{Tables}
+}
+
 \begin{document}
 
 \AtEndDocument{

--- a/main.tex
+++ b/main.tex
@@ -26,8 +26,8 @@
         \centering
         \includegraphics[width=1.5in, clip, keepaspectratio]{images/logo/laxidian-logo.pdf}
     \end{figure}
-    {\huge \textbf{LaXidiaN}} \medskip \\ {\large A \LaTeX template inspired by Obisdian.} \bigskip \\
-    \textbf{This document was written using LaXidiaN, a sophisticated LaTeX template inspired by Obisidian. If you have any feedback you´d like to share, be it a complaint or a new feature you´d like to see, please open an issue or a pull request on our github repository.} \bigskip \\ %
+    {\huge \textbf{LaXidiaN}} \medskip \\ {\large A \LaTeX template inspired by Obsidian.} \bigskip \\
+    \textbf{This document was written using LaXidiaN, a sophisticated LaTeX template inspired by Obsidian. If you have any feedback you´d like to share, be it a complaint or a new feature you´d like to see, please open an issue or a pull request on our github repository.} \bigskip \\ %
     \href{https://github.com/robertodr01/LaXidiaN}{\underline{LaXidiaN repository}}
   \end{center}
   \vfill

--- a/packages.sty
+++ b/packages.sty
@@ -6,7 +6,7 @@
 
 \usepackage{url}
 \usepackage{minted} % code highlighting
-\usepackage{xcolor} % use HEX colors
+\usepackage[dvipsnames]{xcolor} % use HEX colors
 \usepackage[italian, english]{babel}
 \usepackage{colorprofiles}
 

--- a/styles.sty
+++ b/styles.sty
@@ -195,14 +195,22 @@
     \ifthenelse{\equal{#3}{}}{ % TRUE
         \begin{callouts-no-label}{mytip}
             \textcolor{titletip}{\faLightbulbO \space \space \bfseries {#1}}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{mytip}{#3}
             \textcolor{titletip}{\faLightbulbO \space \space \bfseries {#1} (\thetcbcounter)}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }
 }
@@ -214,14 +222,22 @@
     \ifthenelse{\equal{#3}{}}{ % TRUE
         \begin{callouts-no-label}{myfaq}
             \textcolor{titlefaq}{\faQuestionCircle \space \space \bfseries {#1}}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{myfaq}{#3}
             \textcolor{titlefaq}{\faQuestionCircle \space \space \bfseries {#1} (\thetcbcounter)}\par % Title
-            \vspace{0.3cm}
-            #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }    
     
@@ -232,14 +248,22 @@
     \ifthenelse{\equal{#3}{}}{ % TRUE
         \begin{callouts-no-label}{mysuccess}
             \textcolor{titlesuccess}{\faCheckCircle \space \space \bfseries {#1}}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{mysuccess}{#3}
             \textcolor{titlesuccess}{\faCheckCircle \space \space \bfseries {#1} (\thetcbcounter)}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }    
     
@@ -250,14 +274,22 @@
     \ifthenelse{\equal{#3}{}}{ % TRUE
         \begin{callouts-no-label}{myerror}
             \textcolor{titleerror}{\faTimesCircle \space \space \bfseries {#1}}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{myerror}{#3}
             \textcolor{titleerror}{\faTimesCircle \space \space \bfseries {#1} (\thetcbcounter)}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }    
     
@@ -273,14 +305,22 @@
     \ifthenelse{\equal{#4}{}}{ % TRUE
         \begin{callouts-no-label}{#1}
             {\bfseries {#2}}\par % Title
-            \vspace{0.3cm}
-                #3
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{#1}{#4}
             {\bfseries {#2} (\thetcbcounter)\par} % Title
-            \vspace{0.3cm}
-                #3
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }
 
@@ -302,14 +342,22 @@
     \ifthenelse{\equal{#1}{}}{
         \begin{theoremb}{theorem-proofbox}{#3}
             \textcolor{theorem-prooftitle}{ \bfseries Theorem (\thetcbcounter). \space}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{theoremb}
     }{
         \begin{theoremb}{theorem-proofbox}{#3}
             \textcolor{theorem-prooftitle}{ \bfseries Theorem (\thetcbcounter) {#1}. \space}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{theoremb}
     }
 }
@@ -331,9 +379,3 @@
 %     \ifthenelse{\equal{#3}{}}{}{\label{#3}}
 %     \end{theorem-proof}
 % }
-
-
-
-
-
-

--- a/styles.sty
+++ b/styles.sty
@@ -178,14 +178,22 @@
     \ifthenelse{\equal{#3}{}}{ % TRUE
         \begin{callouts-no-label}{lightblue}
             \textcolor{titleinfo}{\faInfoCircle \space \space \bfseries {#1}}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-no-label}
     }{ % FALSE
         \begin{callouts-with-label}{lightblue}{#3}
             \textcolor{titleinfo}{\faInfoCircle \space \space \bfseries {#1} (\thetcbcounter)}\par % Title
-            \vspace{0.3cm}
-                #2
+            \ifx&#2&
+                #2 % #2 is empty
+            \else 
+                \vspace{0.3cm}
+                    #2
+            \fi
         \end{callouts-with-label}
     }
 }


### PR DESCRIPTION
If one were to pass only an empty body parameter (#2) to a callout box, the resulting box would add a 0.3cm vertical space between the title and the body, which was not pleasant. 

This PR addresses the issue by ensuring that when the #2 argument is not provided, the vertical spacing is handled appropriately to eliminate the undesired gap between the title and the body.
